### PR TITLE
Initial prototype of istioctl using kiali validators

### DIFF
--- a/istioctl/cmd/kialicheck.go
+++ b/istioctl/cmd/kialicheck.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kiali/kiali/business"
+)
+
+var (
+	kialiCheckCmd = &cobra.Command{
+		Use:   "kialicheck",
+		Short: "kialicheck",
+		Long: `
+TODO: Long
+`,
+		Example: `
+TODO: Example
+`,
+		// nolint: goimports
+		Args: cobra.NoArgs,
+		RunE: runKialiCheck,
+		//DisableFlagsInUseLine: true,
+	}
+)
+
+func runKialiCheck(c *cobra.Command, args []string) error {
+	businessLayer, err := business.Get("")
+	if err != nil {
+		return fmt.Errorf("error getting business layer: %v", err)
+		// Problem: the above assumes we're already inside the cluster.
+		// "unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"
+		// Workaround?
+		//     ```kubectl proxy --port=8080```
+		//     ```KUBERNETES_SERVICE_HOST=localhost KUBERNETES_SERVICE_PORT=8080 ~/go/out/linux_amd64/release/istioctl experimental kialicheck```
+	}
+
+	istioConfigValidationResults, err := businessLayer.Validations.GetValidations("default", "")
+	if err != nil {
+		return fmt.Errorf("error getting validation results: %v", err)
+		// Problem: Getting "Unauthorized" HTTP response code somewhere in the above. Why?
+		// proxy not working somehow? Works when I curl it directly...
+		// Solution: leave the token blank in business.Get
+		// it's expecting a k8s token. If left blank, kubectl proxy uses what's in the user's file, all is well.
+	}
+
+	for _, v := range istioConfigValidationResults {
+		if !v.Valid {
+			fmt.Printf("%s '%s' has %d problems:\n", v.ObjectType, v.Name, len(v.Checks))
+			for _, c := range v.Checks {
+				fmt.Printf("\t%s: %s <%s>\n", c.Severity, c.Message, c.Path)
+				//TODO: Print the path info more beautifully
+			}
+		}
+	}
+	return nil
+
+	//TODO: Try from Galley?
+}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -109,6 +109,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(dashboard())
 	experimentalCmd.AddCommand(uninjectCommand())
 	experimentalCmd.AddCommand(metricsCmd)
+	experimentalCmd.AddCommand(kialiCheckCmd)
 
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
 		Title:   "Istio Control",


### PR DESCRIPTION
Experimenting with porting kiali checker code to Istio

e.g.
```
crwilson@crwilson:~$ kubectl proxy --port=8080
Starting to serve on 127.0.0.1:8080


crwilson@crwilson:~/go/src/istio.io/istio$ make istioctl && KUBERNETES_SERVICE_HOST=127.0.0.1 KUBERNETES_SERVICE_PORT=8080 ~/go/out/linux_amd64/release/istioctl experimental kialicheck
STATIC=0 GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' bin/gobuild.sh /usr/local/google/home/crwilson/go/out/linux_amd64/release/istioctl ./istioctl/cmd/istioctl

real    0m12.616s
user    0m12.785s
sys     0m2.984s
virtualservice 'bookinfo' has 1 problems:
        error: VirtualService is pointing to a non-existent gateway <spec/gateways[0]>
meshpolicy 'default' has 1 problems:
        error: Mesh-wide Destination Rule enabling mTLS is missing <spec/peers/mtls>
destinationrule 'details' has 1 problems:
        error: This subset's labels are not found in any matching host <spec/subsets[1]>
destinationrule 'ratings' has 3 problems:
        error: This subset's labels are not found in any matching host <spec/subsets[1]>
        error: This subset's labels are not found in any matching host <spec/subsets[2]>
        error: This subset's labels are not found in any matching host <spec/subsets[3]>
```
